### PR TITLE
Use fully qualified names for pylint overgeneral-exceptions

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -426,6 +426,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtin.StandardError,
+                       builtin.Exception,
+                       builtin.BaseException


### PR DESCRIPTION
 for compatability with pylint>=3.0